### PR TITLE
Ajout de l'Id de commande dans l'écran de paramétrage de l'équipement.

### DIFF
--- a/desktop/js/pushbullet.js
+++ b/desktop/js/pushbullet.js
@@ -21,6 +21,9 @@ function addCmdToTable(_cmd) {
     }
     var tr = '<tr class="cmd" data-cmd_id="' + init(_cmd.id) + '">';
     tr += '<td>';
+    tr += '<span>'+_cmd.id+'</span>';
+    tr += '</td>';
+    tr += '<td>';
     tr += '<span>'+_cmd.type+'</span>';
     tr += '</td>';
     tr += '<td>';

--- a/desktop/php/pushbullet.php
+++ b/desktop/php/pushbullet.php
@@ -142,7 +142,7 @@ $eqLogics = eqLogic::byType('pushbullet')
         <table id="table_cmd" class="table table-bordered table-condensed">
             <thead>
                 <tr>
-                    <th>{{Type}}</th><th>{{Nom du device}}</th><th>{{Paramètres}}</th>
+                    <th>{{Id}}</th><th>{{Type}}</th><th>{{Nom du device}}</th><th>{{Paramètres}}</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Ajout de l'Id de commande dans l'écran de paramétrage de l'équipement.
Utile par exemple lorsque l'on souhaite utiliser les appels API event()
